### PR TITLE
AL - Fix -docs creation flow, enable GH pages via API

### DIFF
--- a/.github/workflows/00-publish-docs-to-github-pages-setup.yml
+++ b/.github/workflows/00-publish-docs-to-github-pages-setup.yml
@@ -1,64 +1,60 @@
-
 name: "00-publish-docs-to-github-pages-setup: set up -docs and -docs-qa repos (run once, manually)"
 on: 
   workflow_dispatch:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      TEMPLATE: "https://github.com/ucsb-cs156/TEMPLATE-docs"
+      OWNER: ${{ github.repository_owner }}
+      REPOSITORY: ${{ github.event.repository.name }}
+      OWNER_PLUS_REPOSITORY: ${{ github.repository }}
     steps:
       - name: "Create -docs repo"
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs"
-          DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
-          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
-          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
-      - name: "Set homepage in -docs repo"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo create ${NEW_REPO} --public --template ${TEMPLATE}
+      - name: "Set description and homepage in -docs repo"
+        # This separate step is necessary because of a limitation where --homepage and --template cannot be used together!
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs"
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          DESC="Production documentation for ${OWNER_PLUS_REPOSITORY}"
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
           NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+          gh repo edit ${NEW_REPO} --description "${DESC}" --homepage ${HOMEPAGE}
+      - name: "Enable GitHub Pages in -docs repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs"
+          jq -n '{"build_type": "legacy", "source": {"branch": "main", "path": "/docs"}}' | gh api repos/${OWNER_PLUS_REPOSITORY}${SUFFIX}/pages --input -
       - name: "Create -docs-qa repo"
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs-qa"
-          DESC="Documentation QA site for ${OWNER_PLUS_REPOSITORY}"
-          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
-          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
-      - name: "Set homepage in -docs-qa repo"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo create ${NEW_REPO} --public --template ${TEMPLATE}
+      - name: "Set description and homepage in -docs-qa repo"
+        # This separate step is necessary because of a limitation where --homepage and --template cannot be used together!
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs-qa"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          DESC="QA documentation for ${OWNER_PLUS_REPOSITORY}"
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
           NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+          gh repo edit ${NEW_REPO} --description "${DESC}" --homepage ${HOMEPAGE}
+      - name: "Enable GitHub Pages in -docs-qa repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs-qa"
+          jq -n '{"build_type": "legacy", "source": {"branch": "main", "path": "/docs"}}' | gh api repos/${OWNER_PLUS_REPOSITORY}${SUFFIX}/pages --input -
    


### PR DESCRIPTION
In this PR, we fix a problem with enabling the -docs creation.  This adds a separate step, since --homepage and --template cannot be used together.